### PR TITLE
Handle case where grouping is disabled

### DIFF
--- a/src/main/java/org/joda/money/format/AmountPrinterParser.java
+++ b/src/main/java/org/joda/money/format/AmountPrinterParser.java
@@ -110,6 +110,9 @@ final class AmountPrinterParser implements MoneyPrinter, MoneyParser, Serializab
     }
 
     private boolean isPreGroupingPoint(int remaining, int groupingSize, int extendedGroupingSize) {
+        if (groupingSize == 0) {
+            return false;
+        }
         if (remaining >= groupingSize + extendedGroupingSize) {
             return (remaining - groupingSize) % extendedGroupingSize == 0;
         }
@@ -117,6 +120,9 @@ final class AmountPrinterParser implements MoneyPrinter, MoneyParser, Serializab
     }
 
     private boolean isPostGroupingPoint(int i, int post, int groupingSize, int extendedGroupingSize) {
+        if (groupingSize == 0) {
+            return false;
+        }
         boolean atEnd = (i + 1) >= post;
         if (i > groupingSize) {
             return (i - groupingSize) % extendedGroupingSize == (extendedGroupingSize - 1) && !atEnd;

--- a/src/main/java/org/joda/money/format/AmountPrinterParser.java
+++ b/src/main/java/org/joda/money/format/AmountPrinterParser.java
@@ -110,9 +110,6 @@ final class AmountPrinterParser implements MoneyPrinter, MoneyParser, Serializab
     }
 
     private boolean isPreGroupingPoint(int remaining, int groupingSize, int extendedGroupingSize) {
-        if (groupingSize == 0) {
-            return false;
-        }
         if (remaining >= groupingSize + extendedGroupingSize) {
             return (remaining - groupingSize) % extendedGroupingSize == 0;
         }
@@ -120,9 +117,6 @@ final class AmountPrinterParser implements MoneyPrinter, MoneyParser, Serializab
     }
 
     private boolean isPostGroupingPoint(int i, int post, int groupingSize, int extendedGroupingSize) {
-        if (groupingSize == 0) {
-            return false;
-        }
         boolean atEnd = (i + 1) >= post;
         if (i > groupingSize) {
             return (i - groupingSize) % extendedGroupingSize == (extendedGroupingSize - 1) && !atEnd;

--- a/src/main/java/org/joda/money/format/MoneyAmountStyle.java
+++ b/src/main/java/org/joda/money/format/MoneyAmountStyle.java
@@ -469,8 +469,8 @@ public final class MoneyAmountStyle implements Serializable {
      */
     public MoneyAmountStyle withGroupingSize(Integer groupingSize) {
         int sizeVal = (groupingSize == null ? -1 : groupingSize);
-        if (groupingSize != null && sizeVal <= 0) {
-            throw new IllegalArgumentException("Grouping size must be greater than zero");
+        if (groupingSize != null && sizeVal < 0) {
+            throw new IllegalArgumentException("Grouping size must be greater than or equal to zero");
         }
         if (sizeVal == this.groupingSize) {
             return this;


### PR DESCRIPTION
Related to issue running joda on android 8.0 and above.  The android devs changed the Bulgarian language's
NumberFormatter options to have grouping disabled per ICU4J 59