### PR TITLE
Fix grouping disabled bug (previous fix broke tests)

### DIFF
--- a/src/main/java/org/joda/money/format/MoneyAmountStyle.java
+++ b/src/main/java/org/joda/money/format/MoneyAmountStyle.java
@@ -240,16 +240,13 @@ public final class MoneyAmountStyle implements Serializable {
             protoStyle = (protoStyle == null ? getLocalizedStyle(locale) : protoStyle);
             result = result.withGroupingCharacter(protoStyle.getGroupingCharacter());
         }
-        if (groupingSize < 0) {
+        if (groupingSize < 0 && groupingStyle != GroupingStyle.NONE) {
             protoStyle = (protoStyle == null ? getLocalizedStyle(locale) : protoStyle);
             result = result.withGroupingSize(protoStyle.getGroupingSize());
         }
         if (extendedGroupingSize < 0) {
             protoStyle = (protoStyle == null ? getLocalizedStyle(locale) : protoStyle);
             result = result.withExtendedGroupingSize(protoStyle.getExtendedGroupingSize());
-        }
-        if (protoStyle != null && groupingStyle != protoStyle.getGroupingStyle()) {
-            result = result.withGroupingStyle(protoStyle.getGroupingStyle());
         }
         return result;
     }
@@ -279,17 +276,11 @@ public final class MoneyAmountStyle implements Serializable {
             }
             NumberFormat format = NumberFormat.getCurrencyInstance(locale);
             int size = (format instanceof DecimalFormat ? ((DecimalFormat) format).getGroupingSize() : 3);
-            boolean groupingEnabled = format == null || format.isGroupingUsed();
-            GroupingStyle groupingStyle = GroupingStyle.FULL;
-            if (!groupingEnabled) {
-                groupingStyle = GroupingStyle.NONE;
-                size = -1;
-            }
             protoStyle = new MoneyAmountStyle(
                     symbols.getZeroDigit(),
                     '+', symbols.getMinusSign(),
                     symbols.getMonetaryDecimalSeparator(),
-                    groupingStyle, symbols.getGroupingSeparator(), size, 0, false, false);
+                    GroupingStyle.FULL, symbols.getGroupingSeparator(), size, 0, false, false);
             LOCALIZED_CACHE.putIfAbsent(locale, protoStyle);
         }
         return protoStyle;


### PR DESCRIPTION
The bug is triggered by providing a no group MoneyAmountStyle on a locale that has grouping disabled.

Previously, this could would try to set a group size of zero even though groupStyle is NONE.

Related to issue running joda on android 8.0 and above. The android devs changed the Bulgarian language's
NumberFormatter options to have grouping disabled per ICU4J 59

